### PR TITLE
#1 readme 내 페이지 접근 경로 구분자 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 > Flutter 학습 전 Dart 언어 학습
 > 
 
-[Chapter00. Dart](docs\chapter00.md)
+[Chapter00. Dart](docs/chapter00.md)
 
-[Chapter01. Variables](docs\chapter01.md)
+[Chapter01. Variables](docs/chapter01.md)


### PR DESCRIPTION
- windows 구분자가 아닌 linux 구분자로 변경 -- git 페이지에서 windows 구분자를 제대로 인식하지 못하여 404 페이지로 이동됨